### PR TITLE
"Unprocessable entity (#422)" error fix

### DIFF
--- a/src/models/Whois.php
+++ b/src/models/Whois.php
@@ -31,6 +31,7 @@ class Whois extends ActiveRecord
     public function rules()
     {
         return [
+            [['domain'], 'filter', 'filter' => 'strtolower'],
             [['domain'], DomainValidator::class, 'enableIdn' => true],
         ];
     }


### PR DESCRIPTION
Added new parameter to __rules()__, to fix "Unprocessable entity (#422)" error.