### PR TITLE
Added setter for "zones" attribute in BulkCheckForm model, because wh…

### DIFF
--- a/src/forms/BulkCheckForm.php
+++ b/src/forms/BulkCheckForm.php
@@ -12,7 +12,26 @@ class BulkCheckForm extends Model
 {
     public $fqdns = [];
 
-    public $zones = [];
+    /**
+     * @var array
+     */
+    private $zones = [];
+
+    /**
+     * @return array
+     */
+    public function getZones()
+    {
+        return $this->zones;
+    }
+
+    /**
+     * @param array $zones
+     */
+    public function setZones($zones)
+    {
+        $this->zones = (array)$zones;
+    }
     /**
      * @var array
      */


### PR DESCRIPTION
…en mass domain search if zones is empty throw the php warning "reset() expects parameter 1 to be array, string given"