### PR TITLE
HP-2157: hide preincoming status

### DIFF
--- a/src/models/Domain.php
+++ b/src/models/Domain.php
@@ -405,7 +405,7 @@ class Domain extends Model
 
     public function isPreincoming()
     {
-        return $this->state === static::STATE_PREINCOMING;
+        return false;
     }
 
     public function isIncoming()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified the domain state check, removing the ability to identify a domain as preincoming, which may affect domain transfer processes.

- **Documentation**
	- Updated method signature for clarity on return type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->