### PR TITLE
AHN-2700: Fix 500; zones have not types

### DIFF
--- a/src/views/zone/index.php
+++ b/src/views/zone/index.php
@@ -21,7 +21,6 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php Pjax::begin(array_merge(Yii::$app->params['pjax'], ['enablePushState' => true])) ?>
     <?php $page = IndexPage::begin(compact('model', 'dataProvider')) ?>
 
-        <?= $page->setSearchFormData(compact(['types', 'brands', 'states'])) ?>
         <?php $page->beginContent('main-actions') ?>
             <?php  if (Yii::$app->user->can('zone.create')) : ?>
                 <?= Html::a(Yii::t('hipanel:domain', 'Create zone'), ['@zone/create'], ['class' => 'btn btn-sm btn-success']) ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic pre-population of search form data for types, brands, and states filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->