### PR TITLE
HQD-175: block deprecated DNSSEC algorithms per RFC 8624

### DIFF
--- a/src/Enum/Algorithm.php
+++ b/src/Enum/Algorithm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace hipanel\modules\domain\Enum;
+
+enum Algorithm: int
+{
+    case RsaMd5             = 1;
+    case Dh                 = 2;
+    case DsaSha1            = 3;
+    case RsaSha1            = 5;
+    case DsaNsec3Sha1       = 6;
+    case Rsasha1Nsec3Sha1   = 7;
+    case RsaSha256          = 8;
+    case RsaSha512          = 10;
+    case GostR              = 12;
+    case EcdsaP256Sha256    = 13;
+    case EcdsaP384Sha384    = 14;
+    case Ed25519            = 15;
+    case Ed448              = 16;
+
+    public function isDeprecated(): bool
+    {
+        return match($this) {
+            self::RsaMd5,
+            self::DsaSha1,
+            self::RsaSha1,
+            self::DsaNsec3Sha1,
+            self::Rsasha1Nsec3Sha1,
+            self::GostR => true,
+            default     => false,
+        };
+    }
+}

--- a/src/Enum/DigestType.php
+++ b/src/Enum/DigestType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace hipanel\modules\domain\Enum;
+
+enum DigestType: int
+{
+    case Sha1   = 1;
+    case Sha256 = 2;
+    case GostR  = 3;
+    case Sha384 = 4;
+
+    public function isDeprecated(): bool
+    {
+        return match($this) {
+            self::Sha1, self::GostR => true,
+            default                 => false,
+        };
+    }
+}

--- a/src/grid/DomainGridView.php
+++ b/src/grid/DomainGridView.php
@@ -248,7 +248,7 @@ class DomainGridView extends BoxedGridView
                         'icons' => 'fa-btc',
                         'messages' => [
                             Yii::t('hipanel:domain', 'Domain is premium'),
-                            Yii::t('hipanel:domain', 'Domain is standart'),
+                            Yii::t('hipanel:domain', 'Domain is standard'),
                         ],
                     ]);
                 },

--- a/src/grid/SecdnsGridView.php
+++ b/src/grid/SecdnsGridView.php
@@ -43,14 +43,26 @@ class SecdnsGridView extends BoxedGridView
                 'attribute' => 'digest_alg',
                 'format' => 'raw',
                 'value' => function($model): string {
-                    return Html::tag('span', $model->getDigestAlgorithm());
+                    $alg = $model->getDigestAlgorithm();
+                    if (in_array($model->digest_alg, Secdns::deprecatedAlgorithms(), true)) {
+                        return Html::tag('span', Html::encode($alg), ['class' => 'text-danger'])
+                            . ' '
+                            . Html::tag('span', Yii::t('hipanel:domain', 'Deprecated'), ['class' => 'label label-danger']);
+                    }
+                    return Html::tag('span', Html::encode($alg));
                 },
             ],
             'digest_type' => [
                 'attribute' => 'digest_type',
                 'format' => 'raw',
                 'value' => function($model): string {
-                    return Html::tag('span', $model->getDigestType());
+                    $type = $model->getDigestType();
+                    if (in_array($model->digest_type, Secdns::deprecatedDigestTypes(), true)) {
+                        return Html::tag('span', Html::encode($type), ['class' => 'text-danger'])
+                            . ' '
+                            . Html::tag('span', Yii::t('hipanel:domain', 'Deprecated'), ['class' => 'label label-danger']);
+                    }
+                    return Html::tag('span', Html::encode($type));
                 },
             ],
             'digest' => [
@@ -64,7 +76,13 @@ class SecdnsGridView extends BoxedGridView
                 'attribute' => 'key_alg',
                 'format' => 'raw',
                 'value' => function($model): string {
-                    return Html::tag('span', $model->getKeyAlgorithm());
+                    $alg = $model->getKeyAlgorithm();
+                    if (in_array($model->key_alg, Secdns::deprecatedAlgorithms(), true)) {
+                        return Html::tag('span', Html::encode($alg), ['class' => 'text-danger'])
+                            . ' '
+                            . Html::tag('span', Yii::t('hipanel:domain', 'Deprecated'), ['class' => 'label label-danger']);
+                    }
+                    return Html::tag('span', Html::encode($alg));
                 },
             ],
             'pub_key' => [

--- a/src/models/Secdns.php
+++ b/src/models/Secdns.php
@@ -10,40 +10,12 @@
 
 namespace hipanel\modules\domain\models;
 
-use Exception;
-use hipanel\helpers\ArrayHelper;
-use hipanel\helpers\StringHelper;
-use hipanel\validators\DomainValidator;
-use hiqdev\hiart\ResponseErrorException;
+use hipanel\modules\domain\Enum\Algorithm;
+use hipanel\modules\domain\Enum\DigestType;
 use Yii;
 
 class Secdns extends \hipanel\base\Model
 {
-    /**
-     * Cryptographic algorythm
-     */
-    const ALGORITHM_RSA_MD5 = 1;
-    const ALGORITHM_DH = 2;
-    const ALGORITHM_DSA_SHA1 = 3;
-    const ALGORITHM_RSA_SHA1 = 5;
-    const ALGORITHM_DSA_NSEC3_SHA1 = 6;
-    const ALGORITHM_RSASHA1_NSEC3_SHA1 = 7;
-    const ALGORITHM_RSA_SHA256 = 8;
-    const ALGORITHM_RSA_SHA512 = 10;
-    const ALGORITHM_GOST_R = 12;
-    const ALGORITHM_ECDSA_P256_SHA256 = 13;
-    const ALGORITHM_ECDSA_P384_SHA384 = 14;
-    const ALGORITHM_ED25519 = 15;
-    const ALGORITHM_ED448 = 16;
-
-    /**
-     * Digest types
-     */
-    const DIGEST_TYPE_SHA1 = 1;
-    const DIGEST_TYPE_SHA256 = 2;
-    const DIGEST_TYPE_GOST_R = 3;
-    const DIGEST_TYPE_SHA384 = 4;
-
     const DNSKEY_FLAGS = 257;
     const DNSKEY_PROTOCOL = 3;
 
@@ -62,6 +34,22 @@ class Secdns extends \hipanel\base\Model
             [['digest'], 'filter', 'filter' => 'strtoupper'],
             [['digest_alg', 'key_alg'], 'in', 'range' => array_keys(self::algorithmTypesWithLabels())],
             [['digest_type'], 'in', 'range' => array_keys(self::getDigestTypeLength())],
+            [
+                ['digest_alg', 'key_alg'],
+                'in',
+                'range' => self::deprecatedAlgorithms(),
+                'not' => true,
+                'message' => Yii::t('hipanel:domain', 'This DNSSEC algorithm is deprecated per RFC and MUST NOT be used for new records'),
+                'on' => ['create'],
+            ],
+            [
+                ['digest_type'],
+                'in',
+                'range' => self::deprecatedDigestTypes(),
+                'not' => true,
+                'message' => Yii::t('hipanel:domain', 'This digest type is deprecated per RFC and MUST NOT be used for new records'),
+                'on' => ['create'],
+            ],
             [
                 ['key_alg', 'key_flags', 'key_protocol'],
                 'required',
@@ -107,27 +95,38 @@ class Secdns extends \hipanel\base\Model
         ]);
     }
 
-    /**
-     * SecDNS Algorithms with labels
-     *
-     * @return array
-     */
-    public static function algorithmTypesWithLabels() : array
+    public static function deprecatedAlgorithms(): array
+    {
+        return array_map(
+            fn(Algorithm $a) => $a->value,
+            array_filter(Algorithm::cases(), fn(Algorithm $a) => $a->isDeprecated())
+        );
+    }
+
+    public static function deprecatedDigestTypes(): array
+    {
+        return array_map(
+            fn(DigestType $t) => $t->value,
+            array_filter(DigestType::cases(), fn(DigestType $t) => $t->isDeprecated())
+        );
+    }
+
+    public static function algorithmTypesWithLabels(): array
     {
         return [
-            self::ALGORITHM_RSA_MD5 => Yii::t('hipanel:domain', 'RSA/MD5'),
-            self::ALGORITHM_DH => Yii::t('hipanel:domain', 'Diffie-Hellman'),
-            self::ALGORITHM_DSA_SHA1 => Yii::t('hipanel:domain', 'DSA/SHA1'),
-            self::ALGORITHM_RSA_SHA1 => Yii::t('hipanel:domain', 'RSA/SHA1'),
-            self::ALGORITHM_DSA_NSEC3_SHA1 => Yii::t('hipanel:domain', 'DSA-NSEC3-SHA1'),
-            self::ALGORITHM_RSASHA1_NSEC3_SHA1 => Yii::t('hipanel:domain', 'RSASHA1-NSEC3-SHA1'),
-            self::ALGORITHM_RSA_SHA256 => Yii::t('hipanel:domain', 'RSA/SHA-256'),
-            self::ALGORITHM_RSA_SHA512 => Yii::t('hipanel:domain', 'RSA/SHA-512'),
-            self::ALGORITHM_GOST_R => Yii::t('hipanel:domain', 'GOST R 34.10-2001'),
-            self::ALGORITHM_ECDSA_P256_SHA256 => Yii::t('hipanel:domain', 'ECDSA Curve P-256 with SHA-256'),
-            self::ALGORITHM_ECDSA_P384_SHA384 => Yii::t('hipanel:domain', 'ECDSA Curve P-384 with SHA-384'),
-            self::ALGORITHM_ED25519 => Yii::t('hipanel:domain', 'ED25519'),
-            self::ALGORITHM_ED448 => Yii::t('hipanel:domain', 'ED448'),
+            Algorithm::RsaMd5->value          => Yii::t('hipanel:domain', 'RSA/MD5'),
+            Algorithm::Dh->value              => Yii::t('hipanel:domain', 'Diffie-Hellman'),
+            Algorithm::DsaSha1->value         => Yii::t('hipanel:domain', 'DSA/SHA1'),
+            Algorithm::RsaSha1->value         => Yii::t('hipanel:domain', 'RSA/SHA1'),
+            Algorithm::DsaNsec3Sha1->value    => Yii::t('hipanel:domain', 'DSA-NSEC3-SHA1'),
+            Algorithm::Rsasha1Nsec3Sha1->value => Yii::t('hipanel:domain', 'RSASHA1-NSEC3-SHA1'),
+            Algorithm::RsaSha256->value       => Yii::t('hipanel:domain', 'RSA/SHA-256'),
+            Algorithm::RsaSha512->value       => Yii::t('hipanel:domain', 'RSA/SHA-512'),
+            Algorithm::GostR->value           => Yii::t('hipanel:domain', 'GOST R 34.10-2001'),
+            Algorithm::EcdsaP256Sha256->value => Yii::t('hipanel:domain', 'ECDSA Curve P-256 with SHA-256'),
+            Algorithm::EcdsaP384Sha384->value => Yii::t('hipanel:domain', 'ECDSA Curve P-384 with SHA-384'),
+            Algorithm::Ed25519->value         => Yii::t('hipanel:domain', 'ED25519'),
+            Algorithm::Ed448->value           => Yii::t('hipanel:domain', 'ED448'),
         ];
     }
 
@@ -148,18 +147,13 @@ class Secdns extends \hipanel\base\Model
         return (string) ($algs[$this->$attribute] ?? '');
     }
 
-    /**
-     * Digest types with labels
-     *
-     * @return array
-     */
-    public static function digestTypesWithLabels() : array
+    public static function digestTypesWithLabels(): array
     {
         return [
-            self::DIGEST_TYPE_SHA1 => Yii::t('hipanel:domain', 'SHA-1'),
-            self::DIGEST_TYPE_SHA256 => Yii::t('hipanel:domain', 'SHA-256'),
-            self::DIGEST_TYPE_GOST_R => Yii::t('hipanel:domain', 'GOST R 34.10-2001'),
-            self::DIGEST_TYPE_SHA384 => Yii::t('hipanel:domain', 'SHA-384'),
+            DigestType::Sha1->value   => Yii::t('hipanel:domain', 'SHA-1'),
+            DigestType::Sha256->value => Yii::t('hipanel:domain', 'SHA-256'),
+            DigestType::GostR->value  => Yii::t('hipanel:domain', 'GOST R 34.10-2001'),
+            DigestType::Sha384->value => Yii::t('hipanel:domain', 'SHA-384'),
         ];
     }
 
@@ -170,29 +164,24 @@ class Secdns extends \hipanel\base\Model
         return (string) ($types[$this->digest_type] ?? '');
     }
 
-    /**
-     * Length of digest for digest types
-     *
-     * @return array
-     */
-    public static function getDigestTypeLength() : array
+    public static function getDigestTypeLength(): array
     {
         return [
-            self::DIGEST_TYPE_SHA1 => 32,
-            self::DIGEST_TYPE_SHA256 => 64,
-            self::DIGEST_TYPE_GOST_R => 32,
-            self::DIGEST_TYPE_SHA384 => 96,
+            DigestType::Sha1->value   => 32,
+            DigestType::Sha256->value => 64,
+            DigestType::GostR->value  => 32,
+            DigestType::Sha384->value => 96,
         ];
     }
 
-    public static function protocolTypesWithLabels() : array
+    public static function protocolTypesWithLabels(): array
     {
         return [
             self::DNSKEY_PROTOCOL => Yii::t('hipanel:domain', 'DNSSEC'),
         ];
     }
 
-    public static function flagTypesWithLabels() : array
+    public static function flagTypesWithLabels(): array
     {
         return [
             self::DNSKEY_FLAGS => Yii::t('hipanel:domain', 'KSK'),
@@ -201,7 +190,6 @@ class Secdns extends \hipanel\base\Model
 
     public function validateDigestLength($attr, $value)
     {
-
         $length = self::getDigestTypeLength();
 
         if (strlen($this->$attr) === $length[$this->digest_type]) {
@@ -211,5 +199,4 @@ class Secdns extends \hipanel\base\Model
         $this->addError($attr, Yii::t("hipanel:domain", "Length of `$attr` should be {$length[$this->digest_type]}"));
         return false;
     }
-
 }

--- a/src/views/secdns/create.php
+++ b/src/views/secdns/create.php
@@ -28,7 +28,13 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
             <div class="box-body table-responsive">
                 <?php foreach (Secdns::algorithmTypesWithLabels() as $no => $name): ?>
-                    <p><b><?= $no ?></b> - <i class="text-danger"><?= $name ?></i></p>
+                    <?php $deprecated = in_array($no, Secdns::deprecatedAlgorithms(), true); ?>
+                    <p>
+                        <b><?= $no ?></b> - <i class="<?= $deprecated ? 'text-muted' : 'text-success' ?>"><?= $name ?></i>
+                        <?php if ($deprecated): ?>
+                            <span class="label label-danger"><?= Yii::t('hipanel:domain', 'Deprecated') ?></span>
+                        <?php endif ?>
+                    </p>
                 <?php endforeach ?>
             </div>
         </div>
@@ -40,7 +46,13 @@ $this->params['breadcrumbs'][] = $this->title;
             </div>
             <div class="box-body table-responsive">
                 <?php foreach (Secdns::digestTypesWithLabels() as $no => $name): ?>
-                    <p><b><?= $no ?></b> - <i class="text-danger"><?= $name ?></i></p>
+                    <?php $deprecated = in_array($no, Secdns::deprecatedDigestTypes(), true); ?>
+                    <p>
+                        <b><?= $no ?></b> - <i class="<?= $deprecated ? 'text-muted' : 'text-success' ?>"><?= $name ?></i>
+                        <?php if ($deprecated): ?>
+                            <span class="label label-danger"><?= Yii::t('hipanel:domain', 'Deprecated') ?></span>
+                        <?php endif ?>
+                    </p>
                 <?php endforeach ?>
             </div>
         </div>
@@ -122,7 +134,9 @@ $this->params['breadcrumbs'][] = $this->title;
                         </div>
                         <div class="col-sm-5">
                             <?= $form->field($model, "[$i]digest_alg")->widget(AlgorithmCombo::class, [
-                                'data' => Secdns::algorithmTypesWithLabels(),
+                                'data' => $model->isNewRecord
+                                    ? array_diff_key(Secdns::algorithmTypesWithLabels(), array_flip(Secdns::deprecatedAlgorithms()))
+                                    : Secdns::algorithmTypesWithLabels(),
                                 'hasId' => true,
                                 'formElementSelector' => '.item',
                                 'multiple' => false,
@@ -140,7 +154,9 @@ $this->params['breadcrumbs'][] = $this->title;
                         </div>
                         <div class="col-sm-5">
                             <?= $form->field($model, "[$i]digest_type")->widget(AlgorithmCombo::class, [
-                                'data' => Secdns::digestTypesWithLabels(),
+                                'data' => $model->isNewRecord
+                                    ? array_diff_key(Secdns::digestTypesWithLabels(), array_flip(Secdns::deprecatedDigestTypes()))
+                                    : Secdns::digestTypesWithLabels(),
                                 'hasId' => true,
                                 'formElementSelector' => '.item',
                                 'multiple' => false,
@@ -161,7 +177,9 @@ $this->params['breadcrumbs'][] = $this->title;
                         </div>
                         <div class="col-sm-5">
                             <?= $form->field($model, "[$i]key_alg")->widget(AlgorithmCombo::class, [
-                                'data' => Secdns::algorithmTypesWithLabels(),
+                                'data' => $model->isNewRecord
+                                    ? array_diff_key(Secdns::algorithmTypesWithLabels(), array_flip(Secdns::deprecatedAlgorithms()))
+                                    : Secdns::algorithmTypesWithLabels(),
                                 'hasId' => true,
                                 'formElementSelector' => '.item',
                                 'multiple' => false,

--- a/tests/unit/SecdnsTest.php
+++ b/tests/unit/SecdnsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hipanel\modules\domain\tests\unit;
+
+use hipanel\modules\domain\Enum\Algorithm;
+use hipanel\modules\domain\Enum\DigestType;
+use hipanel\modules\domain\models\Secdns;
+use PHPUnit\Framework\TestCase;
+
+class SecdnsTest extends TestCase
+{
+    public function testDeprecatedAlgorithmsContainsRfc8624Deprecated(): void
+    {
+        $deprecated = Secdns::deprecatedAlgorithms();
+
+        $this->assertContains(Algorithm::RsaMd5->value, $deprecated, 'RSAMD5 must be deprecated');
+        $this->assertContains(Algorithm::DsaSha1->value, $deprecated, 'DSA/SHA-1 must be deprecated');
+        $this->assertContains(Algorithm::RsaSha1->value, $deprecated, 'RSA/SHA-1 must be deprecated');
+        $this->assertContains(Algorithm::DsaNsec3Sha1->value, $deprecated, 'DSA-NSEC3-SHA1 must be deprecated');
+        $this->assertContains(Algorithm::Rsasha1Nsec3Sha1->value, $deprecated, 'RSASHA1-NSEC3-SHA1 must be deprecated');
+        $this->assertContains(Algorithm::GostR->value, $deprecated, 'GOST R must be deprecated');
+    }
+
+    public function testRecommendedAlgorithmsAreNotDeprecated(): void
+    {
+        $deprecated = Secdns::deprecatedAlgorithms();
+
+        $this->assertNotContains(Algorithm::RsaSha256->value, $deprecated, 'RSA/SHA-256 must not be deprecated');
+        $this->assertNotContains(Algorithm::EcdsaP256Sha256->value, $deprecated, 'ECDSA P-256 must not be deprecated');
+        $this->assertNotContains(Algorithm::EcdsaP384Sha384->value, $deprecated, 'ECDSA P-384 must not be deprecated');
+        $this->assertNotContains(Algorithm::Ed25519->value, $deprecated, 'Ed25519 must not be deprecated');
+    }
+
+    public function testDeprecatedDigestTypesContainsSha1AndGost(): void
+    {
+        $deprecated = Secdns::deprecatedDigestTypes();
+
+        $this->assertContains(DigestType::Sha1->value, $deprecated, 'SHA-1 digest must be deprecated');
+        $this->assertContains(DigestType::GostR->value, $deprecated, 'GOST R digest must be deprecated');
+    }
+
+    public function testSha256DigestIsNotDeprecated(): void
+    {
+        $deprecated = Secdns::deprecatedDigestTypes();
+
+        $this->assertNotContains(DigestType::Sha256->value, $deprecated, 'SHA-256 is the required digest and must not be deprecated');
+    }
+
+    public function testDeprecatedAlgorithmsAreRemovedByArrayDiffKey(): void
+    {
+        $allAlgorithms = array_fill_keys(array_column(Algorithm::cases(), 'value'), '');
+
+        $allowed = array_diff_key($allAlgorithms, array_flip(Secdns::deprecatedAlgorithms()));
+
+        foreach (Secdns::deprecatedAlgorithms() as $alg) {
+            $this->assertArrayNotHasKey($alg, $allowed, "Deprecated algorithm $alg must be filtered out");
+        }
+        $this->assertArrayHasKey(Algorithm::RsaSha256->value, $allowed);
+        $this->assertArrayHasKey(Algorithm::EcdsaP256Sha256->value, $allowed);
+        $this->assertArrayHasKey(Algorithm::EcdsaP384Sha384->value, $allowed);
+        $this->assertArrayHasKey(Algorithm::Ed25519->value, $allowed);
+    }
+
+    public function testDeprecatedDigestTypesAreRemovedByArrayDiffKey(): void
+    {
+        $allDigestTypes = array_fill_keys(array_column(DigestType::cases(), 'value'), '');
+
+        $allowed = array_diff_key($allDigestTypes, array_flip(Secdns::deprecatedDigestTypes()));
+
+        foreach (Secdns::deprecatedDigestTypes() as $type) {
+            $this->assertArrayNotHasKey($type, $allowed, "Deprecated digest type $type must be filtered out");
+        }
+        $this->assertArrayHasKey(DigestType::Sha256->value, $allowed);
+        $this->assertArrayHasKey(DigestType::Sha384->value, $allowed);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNSSEC records now display deprecation status with visual indicators for outdated encryption algorithms and digest types.
  * Deprecated options are highlighted and filtered in DNSSEC record creation forms for better clarity.
  * System prevents creating new DNSSEC records using deprecated algorithms or digest types.

* **Bug Fixes**
  * Fixed typo in domain premium status message ("standart" → "standard").

* **Tests**
  * Added test coverage for deprecation detection functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hipanel-module-domain/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->