### PR TITLE
HQD-271: Rename test fixture domain from bladeroot.net to bladeroot-test.net

### DIFF
--- a/tests/_support/Domain.php
+++ b/tests/_support/Domain.php
@@ -13,7 +13,7 @@ namespace hipanel\modules\domain\tests\_support;
 class Domain
 {
     /** @var string */
-    private $name = 'bladeroot.net';
+    private $name = 'bladeroot-test.net';
 
     /** @var string */
     private $domainId;


### PR DESCRIPTION
This name collided with a real domain of the same name on shared dev instances. See the matching rename in hiqdev/mrdp-sql's fill/domain.sql, which creates this fixture.