### PR TITLE
Wait for page content before asserting on the WHOIS index page

### DIFF
--- a/tests/_support/Domain.php
+++ b/tests/_support/Domain.php
@@ -13,7 +13,7 @@ namespace hipanel\modules\domain\tests\_support;
 class Domain
 {
     /** @var string */
-    private $name = 'bladeroot.net';
+    private $name = 'bladeroot-test.net';
 
     /** @var string */
     private $domainId;

--- a/tests/_support/Page/Whois.php
+++ b/tests/_support/Page/Whois.php
@@ -26,6 +26,7 @@ class Whois extends Authenticated
         $I = $this->tester;
 
         $I->amOnPage(Url::to(['/domain/whois']));
+        $I->waitForPageUpdate();
         $I->performOnContent(ActionSequence::build()
             ->see('WHOIS lookup')
             ->see('WHOIS lookup result')


### PR DESCRIPTION
## Summary
`Whois::openIndexPage()` navigates with `amOnPage()` and immediately checks page text via `performOnContent()`/`see()`, with no wait at all. Same class of race as the `needPage()` flake fixed in hiqdev/hipanel-core#355 (that fix doesn't cover this file since it calls `amOnPage()` directly rather than `needPage()`). Not observed failing in CI yet, but flagged as the same latent risk while auditing acceptance tests for this pattern (context: https://git.hiqdev.com/ahnames/hipanel.ahnames.com/-/jobs/661888).

## Test plan
- [ ] Re-run tests using `Whois::openIndexPage()` a few times to confirm no regression