### PR TITLE
Use a real, resolvable domain name in the shared test fixture

### DIFF
--- a/tests/_support/Domain.php
+++ b/tests/_support/Domain.php
@@ -13,7 +13,7 @@ namespace hipanel\modules\domain\tests\_support;
 class Domain
 {
     /** @var string */
-    private $name = 'bladeroot-test.net';
+    private $name = 'bladeroot.net';
 
     /** @var string */
     private $domainId;


### PR DESCRIPTION
## Summary
\`bladeroot-test.net\` doesn't actually exist (no real registration/whois record), unlike \`bladeroot.net\` which is real. \`DomainDnsCest\`/\`DomainNSsCest\`/\`DomainSettingsCest\` all filter \`@domain/index\` by this fixture name expecting to find a pre-seeded row, and got an empty grid instead:

\`\`\`
[TypeError] hipanel\tests\_support\Page\Widget\Grid::getRowDataKeyByNumber(): Return value must be of type string, null returned
\`\`\`

Seen in CI: https://git.hiqdev.com/ahnames/hipanel.ahnames.com/-/jobs/662417 (8 failures, all the same root cause)

## Test plan
- [ ] Re-run \`DomainDnsCest\`/\`DomainNSsCest\`/\`DomainSettingsCest\` to confirm the domain is found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the default test domain from `bladeroot-test.net` to `bladeroot.net`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->