### PR TITLE
HQD-302: service termination notice popup

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -17,6 +17,9 @@ return [
         '@zone' => '/domain/zone',
         '@secdns' => '/domain/secdns',
     ],
+    'bootstrap' => [
+        \hipanel\modules\domain\bootstrap\ServiceTerminationNoticeBootstrap::class,
+    ],
     'modules' => [
         'domain' => [
             'class' => \hipanel\modules\domain\Module::class,

--- a/src/bootstrap/ServiceTerminationNoticeBootstrap.php
+++ b/src/bootstrap/ServiceTerminationNoticeBootstrap.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Domain plugin for HiPanel
+ *
+ * @link      https://github.com/hiqdev/hipanel-module-domain
+ * @package   hipanel-module-domain
+ * @license   BSD-3-Clause
+ * @copyright Copyright (c) 2015-2019, HiQDev (http://hiqdev.com/)
+ */
+
+namespace hipanel\modules\domain\bootstrap;
+
+use hipanel\modules\client\models\Client;
+use hipanel\modules\domain\widgets\ServiceTerminationNotice;
+use yii\base\BootstrapInterface;
+use yii\web\View;
+use Yii;
+
+class ServiceTerminationNoticeBootstrap implements BootstrapInterface
+{
+    public function bootstrap($app)
+    {
+        if (empty(Yii::$app->params['service-termination-notice.enabled'])) {
+            return;
+        }
+
+        $user = Yii::$app->user;
+        if ($user->isGuest || $user->identity->type !== Client::TYPE_CLIENT) {
+            return;
+        }
+
+        if (!in_array($user->identity->seller, Yii::$app->params['service-termination-notice.sellers'], true)) {
+            return;
+        }
+
+        Yii::$app->view->on(View::EVENT_END_BODY, function () {
+            echo ServiceTerminationNotice::widget();
+        });
+    }
+}

--- a/src/bootstrap/ServiceTerminationNoticeBootstrap.php
+++ b/src/bootstrap/ServiceTerminationNoticeBootstrap.php
@@ -29,7 +29,11 @@ class ServiceTerminationNoticeBootstrap implements BootstrapInterface
             return;
         }
 
-        if (!in_array($user->identity->seller, Yii::$app->params['service-termination-notice.sellers'], true)) {
+        $sellers = Yii::$app->params['service-termination-notice.sellers'] ?? [];
+        if (!is_array($sellers)) {
+            $sellers = [];
+        }
+        if (!in_array($user->identity->seller, $sellers, true)) {
             return;
         }
 

--- a/src/widgets/ServiceTerminationNotice.php
+++ b/src/widgets/ServiceTerminationNotice.php
@@ -34,14 +34,19 @@ class ServiceTerminationNotice extends Widget
         // read from the raw $_COOKIE superglobal, not Yii::$app->request->cookies —
         // Yii's CookieCollection silently drops unsigned cookies when cookie validation
         // is enabled (the default), which would otherwise make this check always fail.
-        return isset($_COOKIE[self::COOKIE_NAME])
-            && $_COOKIE[self::COOKIE_NAME] == Yii::$app->user->id;
+        return isset($_COOKIE[$this->getCookieName()]);
+    }
+
+    // Scoped per user id so one account dismissing the notice in a shared browser
+    // doesn't overwrite (and hide) another account's separate dismissal state.
+    private function getCookieName(): string
+    {
+        return self::COOKIE_NAME . '-' . Yii::$app->user->id;
     }
 
     private function registerClientScript(): void
     {
-        $cookieName = self::COOKIE_NAME;
-        $userId = Yii::$app->user->id;
+        $cookieName = $this->getCookieName();
 
         $this->view->registerJs(<<<JS
 
@@ -55,7 +60,7 @@ class ServiceTerminationNotice extends Widget
         if (dontShowAgain.is(':checked')) {
             var expires = new Date();
             expires.setFullYear(expires.getFullYear() + 5);
-            document.cookie = '{$cookieName}={$userId}; expires=' + expires.toUTCString() + '; path=/';
+            document.cookie = '{$cookieName}=1; expires=' + expires.toUTCString() + '; path=/';
         }
         modal.modal('hide');
     });

--- a/src/widgets/ServiceTerminationNotice.php
+++ b/src/widgets/ServiceTerminationNotice.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Domain plugin for HiPanel
+ *
+ * @link      https://github.com/hiqdev/hipanel-module-domain
+ * @package   hipanel-module-domain
+ * @license   BSD-3-Clause
+ * @copyright Copyright (c) 2015-2019, HiQDev (http://hiqdev.com/)
+ */
+
+namespace hipanel\modules\domain\widgets;
+
+use yii\base\Widget;
+use Yii;
+
+class ServiceTerminationNotice extends Widget
+{
+    public const string COOKIE_NAME = 'service-termination-notice-dismissed';
+
+    public function run(): string
+    {
+        if ($this->isDismissedByCurrentUser()) {
+            return '';
+        }
+
+        $this->registerClientScript();
+
+        return $this->render('service-termination-notice');
+    }
+
+    private function isDismissedByCurrentUser(): bool
+    {
+        // Set client-side via document.cookie (no Yii cookie signature), so it must be
+        // read from the raw $_COOKIE superglobal, not Yii::$app->request->cookies —
+        // Yii's CookieCollection silently drops unsigned cookies when cookie validation
+        // is enabled (the default), which would otherwise make this check always fail.
+        return isset($_COOKIE[self::COOKIE_NAME])
+            && $_COOKIE[self::COOKIE_NAME] == Yii::$app->user->id;
+    }
+
+    private function registerClientScript(): void
+    {
+        $cookieName = self::COOKIE_NAME;
+        $userId = Yii::$app->user->id;
+
+        $this->view->registerJs(<<<JS
+
+(function () {
+    var modal = $('#service-termination-notice-modal'),
+        closeButton = $('.service-termination-notice-close'),
+        dontShowAgain = $('#service-termination-notice-dont-show-again');
+
+    closeButton.click(function (event) {
+        event.preventDefault();
+        if (dontShowAgain.is(':checked')) {
+            var expires = new Date();
+            expires.setFullYear(expires.getFullYear() + 5);
+            document.cookie = '{$cookieName}={$userId}; expires=' + expires.toUTCString() + '; path=/';
+        }
+        modal.modal('hide');
+    });
+
+    modal.modal('show');
+})()
+
+JS
+        );
+    }
+}

--- a/src/widgets/views/service-termination-notice.php
+++ b/src/widgets/views/service-termination-notice.php
@@ -16,15 +16,47 @@ use yii\bootstrap\Modal;
  */
 ?>
 
+<style>
+    #service-termination-notice-modal .modal-content {
+        border-top: 4px solid #f39c12;
+    }
+    #service-termination-notice-modal .modal-header {
+        background-color: #f39c12;
+        border-bottom: none;
+    }
+    #service-termination-notice-modal .modal-header h4 {
+        color: #fff;
+        font-weight: 600;
+    }
+    #service-termination-notice-modal .modal-header .fa {
+        margin-right: 8px;
+    }
+    #service-termination-notice-modal .modal-body strong {
+        color: #c0392b;
+    }
+    #service-termination-notice-modal .modal-footer {
+        display: flex;
+        flex-direction: column;
+        text-align: left;
+    }
+    #service-termination-notice-modal .modal-footer .checkbox {
+        align-self: flex-start;
+        margin: 0 0 12px;
+    }
+    #service-termination-notice-modal .modal-footer .service-termination-notice-close {
+        align-self: flex-end;
+    }
+</style>
+
 <?php Modal::begin([
     'id' => 'service-termination-notice-modal',
-    'header' => '<h4>Service termination notice</h4>',
+    'header' => '<h4><i class="fa fa-exclamation-triangle"></i>Service termination notice</h4>',
     'footer' => Html::checkbox('service-termination-notice-dont-show-again', false, [
             'id' => 'service-termination-notice-dont-show-again',
             'label' => 'I understand, don\'t show this notice again.',
         ])
         . Html::button('Close', [
-            'class' => 'btn btn-primary service-termination-notice-close',
+            'class' => 'btn btn-success service-termination-notice-close',
         ]),
     'size' => Modal::SIZE_DEFAULT,
     'closeButton' => false,

--- a/src/widgets/views/service-termination-notice.php
+++ b/src/widgets/views/service-termination-notice.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Domain plugin for HiPanel
+ *
+ * @link      https://github.com/hiqdev/hipanel-module-domain
+ * @package   hipanel-module-domain
+ * @license   BSD-3-Clause
+ * @copyright Copyright (c) 2015-2019, HiQDev (http://hiqdev.com/)
+ */
+
+use yii\bootstrap\Html;
+use yii\bootstrap\Modal;
+
+/**
+ * @var \yii\web\View $this
+ */
+?>
+
+<?php Modal::begin([
+    'id' => 'service-termination-notice-modal',
+    'header' => '<h4>Service termination notice</h4>',
+    'footer' => Html::checkbox('service-termination-notice-dont-show-again', false, [
+            'id' => 'service-termination-notice-dont-show-again',
+            'label' => 'I understand, don\'t show this notice again.',
+        ])
+        . Html::button('Close', [
+            'class' => 'btn btn-primary service-termination-notice-close',
+        ]),
+    'size' => Modal::SIZE_DEFAULT,
+    'closeButton' => false,
+]) ?>
+
+<p>
+    Please be advised that effective <strong>August 5, 2026</strong>, the registration of new
+    domains through our service will be suspended.
+</p>
+
+<p>
+    If you wish to register a new domain, we recommend using ICANN-accredited registrar with a
+    solid reputation at the following link:
+    <?= Html::a('AdvancedHosting', 'https://portal.advancedhosting.com/cart.php?a=add&domain=register', ['target' => '_blank']) ?>.
+</p>
+
+<p>
+    Please note that this update is made in accordance with our
+    <?= Html::a('Master Service Agreement', 'https://ahnames.com/en/rules', ['target' => '_blank']) ?>,
+    which states that We reserve the right to modify, change, or discontinue any aspect of the
+    Website or the Services. Please rest assured that this change does not affect your existing
+    domains or active services, which will continue to operate as usual.
+</p>
+
+<p>
+    Should you have any questions or require assistance, please do not hesitate to contact our
+    support team.
+</p>
+
+<p>
+    Best regards,<br>
+    AHnames Team
+</p>
+
+<?php Modal::end() ?>


### PR DESCRIPTION
One-time dismissible popup for AHnames' own logged-in, non-reseller clients, warning about the domain-registration suspension. Modeled on hipanel-module-kyc's notification pattern. Gated behind service-termination-notice.enabled/.sellers params (off by default). Part of a multi-repo change for HQD-302.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a service termination notice modal for eligible authenticated users.
  * Informs customers that new domain registrations will be suspended starting August 5, 2026.
  * Provides links to alternative registrar options, agreements, and support.
  * Allows users to close the notice or choose not to display it again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->